### PR TITLE
trim trailing slash if present in artifactory URL

### DIFF
--- a/jfrog-access-token-provider-go/internal/job/credentials_provider.go
+++ b/jfrog-access-token-provider-go/internal/job/credentials_provider.go
@@ -48,6 +48,7 @@ func Run() {
 	if err != nil {
 		log.Fatalf("Failed to create config: %v", err)
 	}
+	config.SM_JFROG_BASE_URL = strings.TrimSuffix(config.SM_JFROG_BASE_URL, "/")
 
 	smClient, err := NewSecretsManagerClient(config)
 	if err != nil {


### PR DESCRIPTION
Fix bug that happened if the jFrog Artifactory URL has a trailing slash.