### PR TITLE
Update go version to 1.25 for ibmcloud-iam-user-apikey-provider-go

### DIFF
--- a/ibmcloud-iam-user-apikey-provider-go/Dockerfile
+++ b/ibmcloud-iam-user-apikey-provider-go/Dockerfile
@@ -1,5 +1,5 @@
 # Use official Golang image as a build stage
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
`go.mod` in ibmcloud-iam-user-apikey-provider-go is updated to 1.25 but the Dockerfile still uses the older version of go1.24 due to which the `go mod download` fails.
This PR updates the base image of Dockerfile to 1.25